### PR TITLE
Fix broken input file reduction across passes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: gitlint
   - repo: https://github.com/crate-ci/typos
-    rev: v1.36.3
+    rev: v1.37.2
     hooks:
       - id: typos
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pcap-minimizer"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "bisector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcap-minimizer"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 repository = "https://github.com/bbannier/pcap-minimizer"
 description = "A tool for automatic minimization of PCAPs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,14 @@ impl Passes {
         let mut result = None;
 
         for pass in &self.0 {
+            let current: &Pcap = match result.as_ref() {
+                Some(f) => f,
+                None => input,
+            };
+
             progress.section(format!("Running pass {pass:?}"));
-            let stats = &input.summary().ok()?;
-            if let Some(output) = pass.run(input, stats, test, progress, tcp_only) {
+            let stats = &current.summary().ok()?;
+            if let Some(output) = pass.run(current, stats, test, progress, tcp_only) {
                 result = Some(output);
             }
         }


### PR DESCRIPTION
With 8449a4270f93ee906e0519f0dcc5dd5c412f3d43 we broken the behavior that a reduction from a pass was passed to the same file; instead only reductions from the last pass had an effect.

This not only led to much increased runtime, but possibly also changed output.